### PR TITLE
Disable share buttons and add favorite to course detail page

### DIFF
--- a/src/components/algolia/algolia-course-related.client.tsx
+++ b/src/components/algolia/algolia-course-related.client.tsx
@@ -19,9 +19,9 @@ type Props = {
 const RelatedCourseItem = ({item}: {item: CourseHit}) => {
   const url = new URL(item.url)
   return (
-    <ImageCard imageUrl={item.photo} imageAlt="" id={item.objectID}>
+    <ImageCard imageUrl={item.photo} isArticle aria-labelledby={item.objectID}>
       <div className="flex flex-col">
-        <H3 className="rs-mb-0 order-2">
+        <H3 id={item.objectID} className="rs-mb-0 order-2">
           <ActionLink
             aria-labelledby={item.objectID}
             className="font-roboto font-normal"

--- a/src/components/elements/favorites-list.tsx
+++ b/src/components/elements/favorites-list.tsx
@@ -5,6 +5,7 @@ import {ChatBubbleLeftEllipsisIcon, ClipboardDocumentIcon, EnvelopeIcon, HeartIc
 import {useCopyToClipboard, useIsClient} from "usehooks-ts"
 import {XMarkIcon} from "@heroicons/react/20/solid"
 import {H2} from "./headers"
+import {clsx} from "clsx"
 
 const ShareButtons = () => {
   const [_copiedText, copy] = useCopyToClipboard()
@@ -12,37 +13,51 @@ const ShareButtons = () => {
   const isClient = useIsClient()
   const urlParams = `/courses/favorites?favs=${favs.map(fav => `${fav.uuid}`).join(",")}`
   const copyUrl = isClient ? window.location.origin + urlParams : urlParams
-  const smsCopy = `sms:&body=I saved some Stanford Summer Session courses that looked interesting to me. What do you think? ${copyUrl}`
-  const emailCopy = `mailto:?body=I saved some Stanford Summer Session courses that looked interesting to me. What do you think? ${copyUrl} &subject=Someone wants you to see their list of favorite courses from Stanford Summer Session`
+
+  const smsCopy =
+    "sms:&body=" +
+    encodeURIComponent(
+      `I saved some Stanford Summer Session courses that looked interesting to me. What do you think? ${copyUrl}`
+    )
+  const emailCopy =
+    "mailto:?subject=" +
+    decodeURIComponent("Someone wants you to see their list of favorite courses from Stanford Summer Session") +
+    "&body=" +
+    encodeURIComponent(
+      `I saved some Stanford Summer Session courses that looked interesting to me. What do you think? ${copyUrl}`
+    )
 
   return (
     <>
-      <a
+      <button
         className="flex flex-col items-center font-semibold text-archway-dark no-underline hocus:underline"
-        href={smsCopy}
+        onClick={() => (location.href = smsCopy)}
         data-course-shared="Favorites"
+        disabled={!favs.length}
       >
-        <span className="mb-4 rounded-full bg-spirited-dark p-5">
+        <span className={clsx("mb-4 rounded-full bg-spirited-dark p-5", {"bg-black-60": !favs.length})}>
           <ChatBubbleLeftEllipsisIcon width={30} className="text-white" />
         </span>
         Text
-      </a>
-      <a
+      </button>
+      <button
         className="flex flex-col items-center font-semibold text-archway-dark no-underline hocus:underline"
-        href={emailCopy}
+        onClick={() => (location.href = emailCopy)}
         data-course-shared="Favorites"
+        disabled={!favs.length}
       >
-        <span className="mb-4 rounded-full bg-spirited-dark p-5">
+        <span className={clsx("mb-4 rounded-full bg-spirited-dark p-5", {"bg-black-60": !favs.length})}>
           <EnvelopeIcon width={30} className="text-white" />
         </span>
         Email
-      </a>
+      </button>
       <button
         className="flex flex-col items-center font-semibold hocus:underline"
         onClick={() => copy(copyUrl)}
         data-course-shared="Favorites"
+        disabled={!favs.length}
       >
-        <span className="mb-4 rounded-full bg-spirited-dark p-5">
+        <span className={clsx("mb-4 rounded-full bg-spirited-dark p-5", {"bg-black-60": !favs.length})}>
           <ClipboardDocumentIcon width={30} className="text-white" />
         </span>
         Copy
@@ -80,11 +95,11 @@ const FavoritesList = ({isDisplayOnly = false}) => {
           </div>
         </>
       ) : (
-        <div className="border-b border-archway-dark pb-20">
+        <p className="border-b border-archway-dark pb-20 leading-relaxed">
           Your favorites list is empty. Tap the{" "}
           <HeartIcon width={30} className="inline-block text-spirited-dark" title="Favorite Heart" /> icon on courses
           you’re interested in to see them here. And share them with family and friends.
-        </div>
+        </p>
       )}
       <div className="mt-12 flex flex-row justify-between">
         <ShareButtons />

--- a/src/components/nodes/pages/summer-course/summer-course-page.tsx
+++ b/src/components/nodes/pages/summer-course/summer-course-page.tsx
@@ -7,6 +7,7 @@ import ArcBanner from "@components/patterns/arc-banner"
 import {convertToLocalDateTime} from "@lib/utils/convert-date"
 import FavoritesList from "@components/elements/favorites-list"
 import RelatedCourses from "@components/algolia/algolia-course-related"
+import FavoriteButton from "@components/elements/favorite-button"
 
 type Props = HtmlHTMLAttributes<HTMLDivElement> & {
   node: NodeSumSummerCourse
@@ -34,22 +35,33 @@ const SummerCoursePage = async ({node, ...props}: Props) => {
           </div>
         </div>
       </ArcBanner>
-      <div className="centered relative z-10 my-32 grid grid-cols-12 gap-10 md:gap-32">
-        <div className="order-2 col-span-12 lg:col-span-8">
-          <div className="rs-mb-4 grid grid-cols-1 gap-10 lg:grid-cols-2">
+
+      <div className="centered relative z-10 my-32 flex flex-col justify-between gap-10 md:gap-32 lg:flex-row">
+        <FavoriteButton
+          className="absolute -top-20 right-5 md:right-16 xl:right-0"
+          title={node.title}
+          uuid={node.id}
+          path={node.path}
+          units={node.sumCourseUnits || 0}
+        />
+
+        <div className="lg:w-7/12 2xl:w-8/12">
+          <div className="rs-mb-4 flex flex-col gap-10 lg:flex-row">
             {node.sumCourseImage && (
-              <div className="aspect-h-1 aspect-w-1 relative">
-                <Image
-                  className="rounded-[25px] object-cover"
-                  src={node.sumCourseImage.mediaImage.url}
-                  alt={node.sumCourseImage.mediaImage.alt || ""}
-                  fill
-                  sizes="(max-width: 768px) 300px, 500px"
-                />
+              <div className="lg:w-1/2">
+                <div className="relative aspect-1">
+                  <Image
+                    className="rounded-[25px] object-cover"
+                    src={node.sumCourseImage.mediaImage.url}
+                    alt={node.sumCourseImage.mediaImage.alt || ""}
+                    fill
+                    sizes="(max-width: 992px) 100vw, 700px"
+                  />
+                </div>
               </div>
             )}
             <div className="pt-12 children:mb-5 [&_span]:font-bold">
-              <H2 className="type-2">Details:</H2>
+              <H2 className="type-1">Details:</H2>
 
               {node.sumCourseSchedule && (
                 <div>
@@ -111,19 +123,19 @@ const SummerCoursePage = async ({node, ...props}: Props) => {
           <div>
             {node.sumCourseDescription && (
               <div className="rs-mb-1">
-                <H3 className="type-2 mb-5">Summary:</H3>
+                <H3 className="type-1 mb-5">Summary:</H3>
                 <Wysiwyg html={node.sumCourseDescription.processed} />
               </div>
             )}
             {node.sumCourseNotes && (
-              <>
-                <H3 className="type-2 mb-5">Course notes:</H3>
+              <div className="rs-mb-1">
+                <H3 className="type-1 mb-5">Course notes:</H3>
                 <Wysiwyg html={node.sumCourseNotes?.processed} />
-              </>
+              </div>
             )}
           </div>
         </div>
-        <div className="order-1 col-span-12 lg:col-span-4">
+        <div className="order-first lg:w-5/12 2xl:w-4/12">
           <FavoritesList isDisplayOnly />
         </div>
       </div>

--- a/src/components/patterns/image-card.tsx
+++ b/src/components/patterns/image-card.tsx
@@ -35,7 +35,7 @@ const ImageCard = ({imageUrl, imageAlt, videoUrl, isArticle, children, hasBgColo
     <CardWrapper
       {...props}
       className={twMerge(
-        "centered w-full rounded-[25px] lg:max-w-[920px] lg:max-w-[980px]",
+        "centered w-full rounded-[25px] lg:max-w-[920px] xl:max-w-[980px]",
         clsx(
           {"bg-transparent": hasBgColor, "bg-fog-light": !hasBgColor, "lg:rs-pt-9": hasBgColor && !imageUrl},
           props.className


### PR DESCRIPTION
# READY FOR REVIEW
- (Edit the above to reflect status)

# Summary
- Use flexbox instead of grid. Grid causes overflow on firefox on small screens
- Disable share buttons if no favorites added
- Fixed share urls
- add favorite button to course page
- adjusted font sizes on course detail page
